### PR TITLE
Add a test case for the dumped Symfony2 Router.

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -15,6 +15,7 @@ $benchmark = new Benchmark($iterations);
 
 setupFastRoute($benchmark, $routes, $args);
 setupSymfony2($benchmark, $routes, $args);
+setupSymfony2Optimized($benchmark, $routes, $args);
 setupPux($benchmark, $routes, $args);
 
 $benchmark->execute();


### PR DESCRIPTION
I've added an additional test case for Symfony2 where the routes are dumped, like it should be done in a production environment.

Interestingly, with this change the Symfony2 Router is the fastest on my machine. I'll be interested in the results with the Pux extension.

I didn't update the Readme.md, I'll leave that to you. For reference here are my results (5.4.17).

Unknown route

| Test Name | Time | +Interval | Change |
| --- | --- | --- | --- |
| Symfony2 Dumped | 0.0000399455 | +0.0000000000 | baseline |
| FastRoute | 0.0002344939 | +0.0001945484 | 487% slower |
| Symfony2 | 0.0010168788 | +0.0009769332 | 2446% slower |
| Pux PHP | 0.0012545040 | +0.0012145585 | 3041% slower |

Last route

| Test Name | Time | \+ Interval | Change |
| --- | --- | --- | --- |
| Symfony2 Dumped | 0.0001198003 | +0.0000000000 | baseline |
| FastRoute | 0.0002490872 | +0.0001292869 | 108% slower |
| Symfony2 | 0.0011074704 | +0.0009876701 | 824% slower |
| Pux PHP | 0.0014067766 | +0.0012869763 | 1074% slower |

First route

| Test Name | Time | \+ Interval | Change |
| --- | --- | --- | --- |
| FastRoute | 0.0000158739 | +0.0000000000 | baseline |
| Pux PHP | 0.0000176847 | +0.0000018108 | 11% slower |
| Symfony2 Dumped | 0.0000331372 | +0.0000172633 | 109% slower |
| Symfony2 | 0.0001584002 | +0.0001425263 | 898% slower |
