### PR TITLE
Added aura into the list and some questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,93 @@
-PHP Router Benchmark
-====================
+### Doubts / Findings
 
-The intent here is to benchmark different PHP routing solutions.
+I have added aura router to 
+[php-router-benchmark](https://github.com/tyler-sommer/php-router-benchmark)
+and found aura is the slowest one.
 
-This is a micro-optimization, done purely out of dumb curiosity.
+    $ php run-tests.php 
+    Running 8 tests, 1000 times each...
+    The 100 highest and lowest results will be disregarded.
 
-
-Installation
-------------
-
-Clone the repo, run `composer install`, run `php run-tests.php`.
-
-You can install the Pux extension to test that as well. See Pux docs for more info.
-
-
-Currently
----------
-
-### Last/unknown route (1000 routes)
-
-The first test was done using the C extension version of Pux. 1000 routes, with 9 parameters each.
-
-```bash
-Running 6 tests, 1000 times each...
-The 100 highest and lowest results will be disregarded.
-
-Results:
-Test Name                          	    Time                	+ Interval          	Change
-FastRoute - unknown route (1000 routes)	0.0003282449        	+0.0000000000       	baseline
-FastRoute - last route (1000 routes)	0.0003490779        	+0.0000208330       	6% slower
-Pux ext - last route (1000 routes) 	    0.0008355537        	+0.0005073088       	155% slower
-Pux ext - unknown route (1000 routes)	0.0008565038        	+0.0005282590       	161% slower
-Symfony 2 - unknown route (1000 routes)	0.0049886054        	+0.0046603605       	1420% slower
-Symfony 2 - last route (1000 routes)	0.0054083353        	+0.0050800905       	1548% slower
-```
-
-And the same test again, with the Pux extension disabled:
-
-```bash
-Running 6 tests, 1000 times each...
-The 100 highest and lowest results will be disregarded.
-
-Results:
-Test Name                          	    Time                	+ Interval          	Change
-FastRoute - unknown route (1000 routes)	0.0003558156        	+0.0000000000       	baseline
-FastRoute - last route (1000 routes)	0.0004698372        	+0.0001140216       	32% slower
-Pux PHP - last route (1000 routes) 	    0.0027003917        	+0.0023445761       	659% slower
-Pux PHP - unknown route (1000 routes)	0.0027126130        	+0.0023567975       	662% slower
-Symfony 2 - unknown route (1000 routes)	0.0051302084        	+0.0047743928       	1342% slower
-Symfony 2 - last route (1000 routes)	0.0052936333        	+0.0049378178       	1388% slower
-```
+    For Aura v2 - last route (1000 routes), out of 800 runs, average time was: 0.0060516742 secs.
+    For Aura v2 - unknown route (1000 routes), out of 800 runs, average time was: 0.0060279649 secs.
+    For FastRoute - last route (1000 routes), out of 800 runs, average time was: 0.0002477944 secs.
+    For FastRoute - unknown route (1000 routes), out of 800 runs, average time was: 0.0002375710 secs.
+    For Symfony 2 - last route (1000 routes), out of 800 runs, average time was: 0.0031924027 secs.
+    For Symfony 2 - unknown route (1000 routes), out of 800 runs, average time was: 0.0031264257 secs.
+    For Pux PHP - last route (1000 routes), out of 800 runs, average time was: 0.0021123934 secs.
+    For Pux PHP - unknown route (1000 routes), out of 800 runs, average time was: 0.0020294347 secs.
 
 
-### First route
+    Results:
+    Test Name                          	Time                	+ Interval          	Change
+    FastRoute - unknown route (1000 routes)	0.0002375710        	+0.0000000000       	baseline
+    FastRoute - last route (1000 routes)	0.0002477944        	+0.0000102234       	4% slower
+    Pux PHP - unknown route (1000 routes)	0.0020294347        	+0.0017918637       	754% slower
+    Pux PHP - last route (1000 routes) 	0.0021123934        	+0.0018748224       	789% slower
+    Symfony 2 - unknown route (1000 routes)	0.0031264257        	+0.0028888547       	1216% slower
+    Symfony 2 - last route (1000 routes)	0.0031924027        	+0.0029548317       	1244% slower
+    Aura v2 - unknown route (1000 routes)	0.0060279649        	+0.0057903939       	2437% slower
+    Aura v2 - last route (1000 routes) 	0.0060516742        	+0.0058141032       	2447% slower
 
-```bash
-Running 3 tests, 1000 times each...
-The 100 highest and lowest results will be disregarded.
 
-Results:
-Test Name                          	Time                	+ Interval          	Change
-FastRoute - first route            	0.0000270230        	+0.0000000000       	baseline
-Pux PHP - first route              	0.0000338626        	+0.0000068396       	25% slower
-Symfony 2 - first route            	0.0001849046        	+0.0001578817       	584% slower
-```
+According to the [benchmark results in Pux](https://github.com/c9s/Pux/issues/17#issuecomment-32275754) 
+[Aura.Router](https://github.com/auraphp/Aura.Router) was much faster 
+than Symfony. That made me think to look into this benchmark.
+
+Even if I have not installed Pux I was getting the results. 
+So wondering how should I get the result. Doesn't I get an error?
+
+So I added a script with [php timer](https://github.com/sebastianbergmann/php-timer/) 
+to check the correctness of this.
+
+The benchmark code is at simpetest.php .
+
+One of the things I noticed is fastroute is fast itself.
+When comparing on an average of ~20 ms with aura/router.
+
+Here is the results of `simpletest.php` with 1000 routes having 10 parameters.
+
+    Route found in fast route 
+     Found fast route at 93 ms
+     Not found fast route at 89 ms
+    Route found in aura 
+     From the controller inside aura 999
+     Found aura route at 115 ms
+     Route not found in 121 ms
+    Route found in symfony
+     From the controller inside symfony999
+     Found symfony route at 321 ms
+     Route not found symfony route at 321 ms
+    
+That said the @pmjones (the creator of aura and who is already an
+expert in benchmarking) himself have said 
+
+> I have to caution against reading too much into this. 
+> The routing system is probably not a bottleneck for most apps, and 
+> even the fastest routing system is not likely to have a huge effect 
+> on the end-to-end performance of an app. But even so, 
+> it's nice to have something to compare to. :-)
+
+You can find [here](https://github.com/c9s/Pux/issues/17#issuecomment-32276937)
+
+Some other questions to address is how the controller is assumed in FastRoute.
+May be the assumption is handler is considered as the controller and 
+you want to dispatch it.
+
+In aura and in symfony we can do something like this 
+
+    'controller' => function () {
+        echo "Hello from controller";
+    }
+    
+I am not sure how this could be done in FastRoute.
+
+So to benchmark a system and to say which one performs better 
+you need to know more on the functionalities the library can offer.
+
+When running on a cli I am not sure whether the router assumes to be 
+having the request method as `GET` . If so the result is 
+correct for symfony and fast route. Else the result for the call is wrong.
+The value of `$_SERVER['REQUEST_METHOD']` will not be set, so does `addGet`
+method of aura doesnot find the route and only `add` method is capable of
+finding the result.

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,8 @@
     "tyler-sommer/nice-bench": "dev-master",
     "nikic/fast-route": "dev-master",
     "corneltek/pux": "dev-master",
-    "symfony/routing": "dev-master"
+    "symfony/routing": "dev-master",
+    "aura/router": "dev-develop-2",
+    "phpunit/php-timer": "dev-master"
   }
 }

--- a/run-tests.php
+++ b/run-tests.php
@@ -13,6 +13,7 @@ $args = 9;
 
 $benchmark = new Benchmark($iterations);
 
+setupAura2($benchmark, $routes, $args);
 setupFastRoute($benchmark, $routes, $args);
 setupSymfony2($benchmark, $routes, $args);
 setupPux($benchmark, $routes, $args);

--- a/simpletest.php
+++ b/simpletest.php
@@ -1,0 +1,152 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+$routes = 1000;
+$args = 10;
+
+setupFastRoute($routes, $args);
+setupAuraRouterv2($routes, $args);
+setupSymfony2($routes, $args);
+/**
+ * Sets up FastRoute tests
+ */
+function setupFastRoute($routes, $args)
+{
+    $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
+    $lastStr = '';
+    PHP_Timer::start();
+    $router = FastRoute\simpleDispatcher(function ($router) use ($routes, $argString, &$lastStr) {
+            for ($i = 0, $str = 'a'; $i < $routes; $i++, $str++) {
+                $router->addRoute('GET', '/' . $str . '/' . $argString, 'handler' . $i);
+                $lastStr = $str;
+            }
+        });
+    $route = $router->dispatch('GET', '/' . $lastStr . '/' . $argString);
+    $time = PHP_Timer::stop();
+    if ($route) {
+        echo "Route found in fast route " . PHP_EOL;
+    }
+    echo " Found fast route at " . PHP_Timer::secondsToTimeString($time) . PHP_EOL;
+    
+    $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
+    $lastStr = '';
+    PHP_Timer::start();
+    $router = FastRoute\simpleDispatcher(function ($router) use ($routes, $argString, &$lastStr) {
+            for ($i = 0, $str = 'a'; $i < $routes; $i++, $str++) {
+                $router->addRoute('GET', '/' . $str . '/' . $argString, 'handler' . $i);
+                $lastStr = $str;
+            }
+        });    
+    $route = $router->dispatch('GET', '/not-even-real');
+    $time = PHP_Timer::stop();
+    if (! $route) {
+        echo "Route found in fast route " . PHP_EOL;
+    }
+    echo " Not found fast route at " . PHP_Timer::secondsToTimeString($time) . PHP_EOL;
+}
+
+/**
+ * Sets up Symfony 2 tests
+ */
+function setupSymfony2($routes, $args)
+{
+    $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
+    $lastStr = '';
+    PHP_Timer::start();
+    $sfRoutes = new Symfony\Component\Routing\RouteCollection();
+    $router = new Symfony\Component\Routing\Matcher\UrlMatcher($sfRoutes, new Symfony\Component\Routing\RequestContext());
+    for ($i = 0, $str = 'a'; $i < $routes; $i++, $str++) {
+        $sfRoutes->add($str, new Symfony\Component\Routing\Route(
+            '/' . $str . '/' . $argString, 
+            array(
+                'controller' => function () use ($i) {
+                    echo ' From the controller inside symfony' . $i . PHP_EOL;
+                }
+            )
+        ));
+        $lastStr = $str;
+    }
+    $route = $router->match('/' . $lastStr . '/' . $argString); 
+    $time = PHP_Timer::stop();
+    if ($route) {
+        echo "Route found in symfony" . PHP_EOL;
+        echo $route['controller']();
+    }
+    echo " Found symfony route at " . PHP_Timer::secondsToTimeString($time) . PHP_EOL;
+    
+    $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
+    $lastStr = '';
+    PHP_Timer::start();    
+    $sfRoutes = new Symfony\Component\Routing\RouteCollection();
+    $router = new Symfony\Component\Routing\Matcher\UrlMatcher($sfRoutes, new Symfony\Component\Routing\RequestContext());
+    for ($i = 0, $str = 'a'; $i < $routes; $i++, $str++) {
+        $sfRoutes->add($str, new Symfony\Component\Routing\Route(
+            '/' . $str . '/' . $argString, 
+            array(
+                'controller' => function () use ($i) {
+                    echo ' From the controller inside symfony' . $i . PHP_EOL;
+                }
+            )
+        ));
+        $lastStr = $str;
+    }
+    try {
+        $route = $router->match('/not-even-real');
+    } catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) { 
+        $time = PHP_Timer::stop();
+        echo " Route not found symfony route at " . PHP_Timer::secondsToTimeString($time) . PHP_EOL;
+    }
+}
+
+function setupAuraRouterv2($routes, $args)
+{
+    $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
+    $lastStr = '';
+    PHP_Timer::start();
+    $router = new Aura\Router\Router(
+        new Aura\Router\RouteCollection(
+            new Aura\Router\RouteFactory()
+        )
+    );
+    for ($i = 0, $str = 'a'; $i < $routes; $i++, $str++) {
+        $router->add('handler' . $i, '/' . $str . '/' . $argString)
+            ->addValues(array(
+                'controller' => function () use ($i) {
+                    echo ' From the controller inside aura ' . $i . PHP_EOL;
+                }
+            ));
+        $lastStr = $str;
+    }
+    
+    $route = $router->match('/' . $lastStr . '/' . $argString, $_SERVER);
+    $time = PHP_Timer::stop();
+    if ($route) {
+       echo "Route found in aura " . PHP_EOL;
+       echo $route->params['controller']();
+    } else {
+        echo '/' . $lastStr . '/' . $argString . PHP_EOL;
+    }
+    echo " Found aura route at " . PHP_Timer::secondsToTimeString($time) . PHP_EOL;
+    
+    $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
+    $lastStr = '';
+    PHP_Timer::start();
+    $router = new Aura\Router\Router(
+        new Aura\Router\RouteCollection(
+            new Aura\Router\RouteFactory()
+        )
+    );
+    for ($i = 0, $str = 'a'; $i < $routes; $i++, $str++) {
+        $router->add('handler' . $i, '/' . $str . '/' . $argString)
+            ->addValues(array(
+                'controller' => function () use ($i) {
+                    echo ' From the controller inside aura ' . $i . PHP_EOL;
+                }
+            ));
+        $lastStr = $str;
+    }
+    $route = $router->match('/not-even-real', $_SERVER);
+    $time = PHP_Timer::stop();
+    if (! $route) {
+        echo " Route not found in " . PHP_Timer::secondsToTimeString($time) . PHP_EOL;
+    }    
+}

--- a/tests.php
+++ b/tests.php
@@ -83,3 +83,34 @@ function setupSymfony2(Benchmark $benchmark, $routes, $args)
             } catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) { }
         });
 }
+
+/**
+ * Sets up Aura v2 tests
+ * 
+ * https://github.com/auraphp/Aura.Router
+ */
+function setupAura2(Benchmark $benchmark, $routes, $args)
+{
+    $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
+    $lastStr = '';
+    $router = new Aura\Router\Router(
+        new Aura\Router\RouteCollection(
+            new Aura\Router\RouteFactory()
+        )
+    );
+    for ($i = 0, $str = 'a'; $i < $routes; $i++, $str++) {
+        $router->add($str, '/' . $str . '/' . $argString)
+            ->addValues(array(
+                'controller' => 'handler' . $i
+            ));
+        $lastStr = $str;
+    }
+
+    $benchmark->register(sprintf('Aura v2 - last route (%s routes)', $routes), function () use ($router, $lastStr, $argString) {
+        $route = $router->match('/' . $lastStr . '/' . $argString, $_SERVER);
+    });
+
+    $benchmark->register(sprintf('Aura v2 - unknown route (%s routes)', $routes), function () use ($router) {
+        $route = $router->match('/not-even-real', $_SERVER);
+    });
+}


### PR DESCRIPTION
Hi , 

I have added aura to the benchmark for testing. And it is found as the slowest one.

That is what I re-wrote in README.md .

I have added aura router to [php-router-benchmark](https://github.com/tyler-sommer/php-router-benchmark) and found aura is the slowest one.

```
$ php run-tests.php 
Running 8 tests, 1000 times each...
The 100 highest and lowest results will be disregarded.

For Aura v2 - last route (1000 routes), out of 800 runs, average time was: 0.0060516742 secs.
For Aura v2 - unknown route (1000 routes), out of 800 runs, average time was: 0.0060279649 secs.
For FastRoute - last route (1000 routes), out of 800 runs, average time was: 0.0002477944 secs.
For FastRoute - unknown route (1000 routes), out of 800 runs, average time was: 0.0002375710 secs.
For Symfony 2 - last route (1000 routes), out of 800 runs, average time was: 0.0031924027 secs.
For Symfony 2 - unknown route (1000 routes), out of 800 runs, average time was: 0.0031264257 secs.
For Pux PHP - last route (1000 routes), out of 800 runs, average time was: 0.0021123934 secs.
For Pux PHP - unknown route (1000 routes), out of 800 runs, average time was: 0.0020294347 secs.


Results:
Test Name                           Time                    + Interval              Change
FastRoute - unknown route (1000 routes) 0.0002375710            +0.0000000000           baseline
FastRoute - last route (1000 routes)    0.0002477944            +0.0000102234           4% slower
Pux PHP - unknown route (1000 routes)   0.0020294347            +0.0017918637           754% slower
Pux PHP - last route (1000 routes)  0.0021123934            +0.0018748224           789% slower
Symfony 2 - unknown route (1000 routes) 0.0031264257            +0.0028888547           1216% slower
Symfony 2 - last route (1000 routes)    0.0031924027            +0.0029548317           1244% slower
Aura v2 - unknown route (1000 routes)   0.0060279649            +0.0057903939           2437% slower
Aura v2 - last route (1000 routes)  0.0060516742            +0.0058141032           2447% slower
```

According to the [benchmark results in Pux](https://github.com/c9s/Pux/issues/17#issuecomment-32275754) [aura/router](https://github.com/auraphp/Aura.Router) was much faster 
than symfony. That made me think to look into this benchmark.

Even if I have not installed Pux I was getting the results.  So wondering how should I get the result. Doesn't I get an error?

So I added a script with [php timer](https://github.com/sebastianbergmann/php-timer/) to check the correctness of this.

The benchmark code is at simpetest.php .

One of the things I noticed is fastroute is fast itself. When comparing on an average of ~20 ms with aura/router.

Here is the results of `simpletest.php` with 1000 routes having 10 parameters.

```
Route found in fast route 
 Found fast route at 93 ms
 Not found fast route at 89 ms
Route found in aura 
 From the controller inside aura 999
 Found aura route at 115 ms
 Route not found in 121 ms
Route found in symfony
 From the controller inside symfony999
 Found symfony route at 321 ms
 Route not found symfony route at 321 ms
```

That said the @pmjones (the creator of aura and who is already an expert in benchmarking) himself have said  

> I have to caution against reading too much into this. 
> The routing system is probably not a bottleneck for most apps, and 
> even the fastest routing system is not likely to have a huge effect 
> on the end-to-end performance of an app. But even so, 
> it's nice to have something to compare to. :-)

You can find [here](https://github.com/c9s/Pux/issues/17#issuecomment-32276937)

Some other questions to address is how the controller is assumed in FastRoute. May be the assumption is handler is considered as the controller and you want to dispatch it. 

In aura and in symfony we can do something like this 

```
'controller' => function () {
    echo "Hello from controller";
}
```

I am not sure how this could be done in FastRoute.

So to benchmark a system and to say which one performs better you need to know more on the functionalities the library can offer.

When running on a cli I am not sure whether the router assumes to be having the request method as `GET` . If so the result is correct for symfony and fast route. Else the result for the call is wrong.
The value of `$_SERVER['REQUEST_METHOD']` will not be set, so does `addGet` method of aura doesnot find the route and only `add` method is capable of finding the result.

Interested to hear your thoughts on this.

Thank you.
