### PR TITLE
Benchmark Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /vendor/*
 composer.lock
-sf2router.php
+.cache

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "nikic/fast-route": "dev-master",
     "corneltek/pux": "dev-master",
     "symfony/routing": "dev-master",
-    "aura/router": "dev-develop-2"
+    "aura/router": "dev-develop-2",
+    "adambrett/router": "dev-master"
   }
 }

--- a/run-tests-cached.php
+++ b/run-tests-cached.php
@@ -1,0 +1,23 @@
+<?php
+
+use TylerSommer\Nice\Benchmark\Benchmark;
+use TylerSommer\Nice\Benchmark\ResultPrinter\MarkdownPrinter;
+
+error_reporting(E_ALL);
+
+require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/tests-cached.php';
+
+$iterations = 1000;
+$routes = 1000;
+$args = 9;
+
+$benchmark = new Benchmark($iterations, new MarkdownPrinter());
+
+setupFastRouteCached($benchmark, $routes, $args);
+setupSymfony2Optimized($benchmark, $routes, $args);
+setupAura2Cached($benchmark, $routes, $args);
+setupPuxCached($benchmark, $routes, $args);
+setupABRouter($benchmark, $routes, $args);
+
+$benchmark->execute();

--- a/run-tests.php
+++ b/run-tests.php
@@ -19,5 +19,6 @@ setupFastRoute($benchmark, $routes, $args);
 setupSymfony2($benchmark, $routes, $args);
 setupSymfony2Optimized($benchmark, $routes, $args);
 setupPux($benchmark, $routes, $args);
+setupABRouter($benchmark, $routes, $args);
 
 $benchmark->execute();

--- a/run-tests.php
+++ b/run-tests.php
@@ -17,7 +17,6 @@ $benchmark = new Benchmark($iterations, new MarkdownPrinter());
 setupAura2($benchmark, $routes, $args);
 setupFastRoute($benchmark, $routes, $args);
 setupSymfony2($benchmark, $routes, $args);
-setupSymfony2Optimized($benchmark, $routes, $args);
 setupPux($benchmark, $routes, $args);
 setupABRouter($benchmark, $routes, $args);
 

--- a/tests-cached.php
+++ b/tests-cached.php
@@ -1,0 +1,161 @@
+<?php
+
+use TylerSommer\Nice\Benchmark\Benchmark;
+
+require __DIR__ . '/tests.php';
+
+define('CACHE_DIR', __DIR__ . '/.cache');
+
+if (!is_dir(CACHE_DIR)) {
+    mkdir(CACHE_DIR, 0777, true);
+}
+
+/**
+ * Sets up FastRoute dumped
+ */
+function setupFastRouteCached(Benchmark $benchmark, $numRoutes, $args)
+{
+    $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
+
+    $routes = getRoutes($numRoutes, $argString);
+    $firstStr = $routes[0];
+    $lastStr = $routes[$numRoutes - 1];
+
+    $router = FastRoute\simpleDispatcher(function ($router) use ($routes) {
+        foreach ($routes as $i => $route) {
+            $router->addRoute('GET', $route, 'handler' . $i);
+        }
+    });
+
+    file_put_contents(CACHE_DIR . '/fastroute.php', serialize($router));
+    // $benchmark->register(sprintf('FastRoute Cached - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
+    //     $router = unserialize(file_get_contents(CACHE_DIR . '/fastroute.php'));
+    //     $route = $router->dispatch('GET', $firstStr);
+    // });
+
+    $benchmark->register(sprintf('FastRoute Cached - last route (%s routes)', $numRoutes), function () use ($routes, $lastStr) {
+        $router = unserialize(file_get_contents(CACHE_DIR . '/fastroute.php'));
+        $route = $router->dispatch('GET', $lastStr);
+    });
+
+    $benchmark->register(sprintf('FastRoute Cached - unknown route (%s routes)', $numRoutes), function () use ($routes) {
+        $router = unserialize(file_get_contents(CACHE_DIR . '/fastroute.php'));
+        $route = $router->dispatch('GET', '/not-even-real');
+    });
+}
+
+/**
+ * Sets up Symfony2 optimized tests
+ */
+function setupSymfony2Optimized(Benchmark $benchmark, $numRoutes, $args)
+{
+    $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
+
+    $routes = getRoutes($numRoutes, $argString);
+    $firstStr = $routes[0];
+    $lastStr = $routes[$numRoutes - 1];
+
+    $sfRoutes = new Symfony\Component\Routing\RouteCollection();
+
+    foreach ($routes as $i => $route) {
+        $sfRoutes->add($route, new Symfony\Component\Routing\Route($route, array('controller' => 'handler' . $i)));
+    }
+
+    $dumper = new Symfony\Component\Routing\Matcher\Dumper\PhpMatcherDumper($sfRoutes);
+    file_put_contents(CACHE_DIR . '/sf2router.php', $dumper->dump());
+
+    require_once CACHE_DIR . '/sf2router.php';
+    // $benchmark->register(sprintf('Symfony2 Dumped - first route (%s routes)', $numRoutes), function () use ($firstStr) {
+    //     $router = new ProjectUrlMatcher(new Symfony\Component\Routing\RequestContext());
+    //     $route = $router->match($firstStr);
+    // });
+
+    $benchmark->register(sprintf('Symfony2 Dumped - last route (%s routes)', $numRoutes), function () use ($lastStr) {
+        $router = new ProjectUrlMatcher(new Symfony\Component\Routing\RequestContext());
+        $route = $router->match($lastStr);
+    });
+
+    $benchmark->register(sprintf('Symfony2 Dumped - unknown route (%s routes)', $numRoutes), function () {
+        try {
+            $router = new ProjectUrlMatcher(new Symfony\Component\Routing\RequestContext());
+            $route = $router->match('/not-even-real');
+        } catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) { }
+    });
+}
+
+/**
+ * Sets up Pux tests
+ */
+function setupPuxCached(Benchmark $benchmark, $numRoutes, $args)
+{
+    $argString = implode('/', array_map(function ($i) { return ':arg' . $i; }, range(1, $args)));
+
+    $routes = getRoutes($numRoutes, $argString);
+    $firstStr = $routes[0];
+    $lastStr = $routes[$numRoutes - 1];
+
+    $router = new Pux\Mux;
+    foreach ($routes as $i => $route) {
+        $router->add($route, 'handler' . $i);
+    }
+
+    file_put_contents(CACHE_DIR . '/pux.php', serialize($router));
+    // $benchmark->register(sprintf('Pux PHP Cached - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
+    //     $router = unserialize(file_get_contents(CACHE_DIR . '/pux.php'));
+    //     $route = $router->match($firstStr);
+    // });
+
+    $benchmark->register(sprintf('Pux PHP Cached - last route (%s routes)', $numRoutes), function () use ($routes, $lastStr) {
+        $router = unserialize(file_get_contents(CACHE_DIR . '/pux.php'));
+        $route = $router->match($lastStr);
+    });
+
+    $benchmark->register(sprintf('Pux PHP Cached - unknown route (%s routes)', $numRoutes), function () use ($routes) {
+        $router = unserialize(file_get_contents(CACHE_DIR . '/pux.php'));
+        $route = $router->match('GET', '/not-even-real');
+    });
+}
+
+/**
+ * Sets up Aura v2 tests
+ *
+ * https://github.com/auraphp/Aura.Router
+ */
+function setupAura2Cached(Benchmark $benchmark, $numRoutes, $args)
+{
+    $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
+    $routes = getRoutes($numRoutes, $argString);
+    $firstStr = $routes[0];
+    $lastStr = $routes[$numRoutes - 1];
+
+    $router = new Aura\Router\Router(
+        new Aura\Router\RouteCollection(
+            new Aura\Router\RouteFactory()
+        )
+    );
+
+    foreach ($routes as $i => $route) {
+        $router->add($route, $route)
+            ->addValues(array(
+                'controller' => 'handler' . $i
+            ));
+    }
+
+    file_put_contents(CACHE_DIR . '/aura2.php', serialize($router));
+
+
+    // $benchmark->register(sprintf('Aura v2 - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
+    //     $router = unserialize(file_get_contents(CACHE_DIR . '/aura2.php'));
+    //     $route = $router->match($firstStr, $_SERVER);
+    // });
+
+    $benchmark->register(sprintf('Aura v2 Cached - last route (%s routes)', $numRoutes), function () use ($routes, $lastStr) {
+        $router = unserialize(file_get_contents(CACHE_DIR . '/aura2.php'));
+        $route = $router->match($lastStr, $_SERVER);
+    });
+
+    $benchmark->register(sprintf('Aura v2 Cached - unknown route (%s routes)', $numRoutes), function () use ($routes) {
+        $router = unserialize(file_get_contents(CACHE_DIR . '/aura2.php'));
+        $route = $router->match('/not-even-real', $_SERVER);
+    });
+}

--- a/tests.php
+++ b/tests.php
@@ -143,45 +143,6 @@ function setupSymfony2(Benchmark $benchmark, $numRoutes, $args)
 }
 
 /**
- * Sets up Symfony2 optimized tests
- */
-function setupSymfony2Optimized(Benchmark $benchmark, $numRoutes, $args)
-{
-    $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
-
-    $routes = getRoutes($numRoutes, $argString);
-    $firstStr = $routes[0];
-    $lastStr = $routes[$numRoutes - 1];
-
-    $sfRoutes = new Symfony\Component\Routing\RouteCollection();
-
-    foreach ($routes as $i => $route) {
-        $sfRoutes->add($route, new Symfony\Component\Routing\Route($route, array('controller' => 'handler' . $i)));
-    }
-
-    $dumper = new Symfony\Component\Routing\Matcher\Dumper\PhpMatcherDumper($sfRoutes);
-    file_put_contents(__DIR__ . '/sf2router.php', $dumper->dump());
-
-    require_once __DIR__ . '/sf2router.php';
-    $benchmark->register(sprintf('Symfony2 Dumped - first route (%s routes)', $numRoutes), function () use ($firstStr) {
-        $router = new ProjectUrlMatcher(new Symfony\Component\Routing\RequestContext());
-        $route = $router->match($firstStr);
-    });
-
-    $benchmark->register(sprintf('Symfony2 Dumped - last route (%s routes)', $numRoutes), function () use ($lastStr) {
-        $router = new ProjectUrlMatcher(new Symfony\Component\Routing\RequestContext());
-        $route = $router->match($lastStr);
-    });
-
-    $benchmark->register(sprintf('Symfony2 Dumped - unknown route (%s routes)', $numRoutes), function () {
-        try {
-            $router = new ProjectUrlMatcher(new Symfony\Component\Routing\RequestContext());
-            $route = $router->match('/not-even-real');
-        } catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) { }
-    });
-}
-
-/**
  * Sets up Aura v2 tests
  *
  * https://github.com/auraphp/Aura.Router

--- a/tests.php
+++ b/tests.php
@@ -34,15 +34,15 @@ function setupFastRoute(Benchmark $benchmark, $numRoutes, $args)
     $firstStr = $routes[0];
     $lastStr = $routes[$numRoutes - 1];
 
-    $benchmark->register(sprintf('FastRoute - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
-        $router = FastRoute\simpleDispatcher(function ($router) use ($routes) {
-            foreach ($routes as $i => $route) {
-                $router->addRoute('GET', $route, 'handler' . $i);
-            }
-        });
+    // $benchmark->register(sprintf('FastRoute - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
+    //     $router = FastRoute\simpleDispatcher(function ($router) use ($routes) {
+    //         foreach ($routes as $i => $route) {
+    //             $router->addRoute('GET', $route, 'handler' . $i);
+    //         }
+    //     });
 
-        $route = $router->dispatch('GET', $firstStr);
-    });
+    //     $route = $router->dispatch('GET', $firstStr);
+    // });
 
     $benchmark->register(sprintf('FastRoute - last route (%s routes)', $numRoutes), function () use ($routes, $lastStr) {
         $router = FastRoute\simpleDispatcher(function ($router) use ($routes) {
@@ -76,13 +76,13 @@ function setupPux(Benchmark $benchmark, $numRoutes, $args)
     $firstStr = $routes[0];
     $lastStr = $routes[$numRoutes - 1];
 
-    $benchmark->register(sprintf('Pux PHP - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
-        $router = new Pux\Mux;
-        foreach ($routes as $i => $route) {
-            $router->add($route, 'handler' . $i);
-        }
-        $route = $router->match($firstStr);
-    });
+    // $benchmark->register(sprintf('Pux PHP - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
+    //     $router = new Pux\Mux;
+    //     foreach ($routes as $i => $route) {
+    //         $router->add($route, 'handler' . $i);
+    //     }
+    //     $route = $router->match($firstStr);
+    // });
 
     $benchmark->register(sprintf('Pux PHP - last route (%s routes)', $numRoutes), function () use ($routes, $lastStr) {
         $router = new Pux\Mux;
@@ -112,14 +112,14 @@ function setupSymfony2(Benchmark $benchmark, $numRoutes, $args)
     $firstStr = $routes[0];
     $lastStr = $routes[$numRoutes - 1];
 
-    $benchmark->register(sprintf('Symfony2 - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
-        $sfRoutes = new Symfony\Component\Routing\RouteCollection();
-        $router = new Symfony\Component\Routing\Matcher\UrlMatcher($sfRoutes, new Symfony\Component\Routing\RequestContext());
-        foreach ($routes as $i => $route) {
-            $sfRoutes->add($route, new Symfony\Component\Routing\Route($route, array('controller' => 'handler' . $i)));
-        }
-        $route = $router->match($firstStr);
-    });
+    // $benchmark->register(sprintf('Symfony2 - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
+    //     $sfRoutes = new Symfony\Component\Routing\RouteCollection();
+    //     $router = new Symfony\Component\Routing\Matcher\UrlMatcher($sfRoutes, new Symfony\Component\Routing\RequestContext());
+    //     foreach ($routes as $i => $route) {
+    //         $sfRoutes->add($route, new Symfony\Component\Routing\Route($route, array('controller' => 'handler' . $i)));
+    //     }
+    //     $route = $router->match($firstStr);
+    // });
 
     $benchmark->register(sprintf('Symfony2 - last route (%s routes)', $numRoutes), function () use ($routes, $lastStr) {
         $sfRoutes = new Symfony\Component\Routing\RouteCollection();
@@ -154,22 +154,22 @@ function setupAura2(Benchmark $benchmark, $numRoutes, $args)
     $firstStr = $routes[0];
     $lastStr = $routes[$numRoutes - 1];
 
-    $benchmark->register(sprintf('Aura v2 - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
-        $router = new Aura\Router\Router(
-            new Aura\Router\RouteCollection(
-                new Aura\Router\RouteFactory()
-            )
-        );
+    // $benchmark->register(sprintf('Aura v2 - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
+    //     $router = new Aura\Router\Router(
+    //         new Aura\Router\RouteCollection(
+    //             new Aura\Router\RouteFactory()
+    //         )
+    //     );
 
-        foreach ($routes as $i => $route) {
-            $router->add($route, $route)
-                ->addValues(array(
-                    'controller' => 'handler' . $i
-                ));
-        }
+    //     foreach ($routes as $i => $route) {
+    //         $router->add($route, $route)
+    //             ->addValues(array(
+    //                 'controller' => 'handler' . $i
+    //             ));
+    //     }
 
-        $route = $router->match($firstStr, $_SERVER);
-    });
+    //     $route = $router->match($firstStr, $_SERVER);
+    // });
 
     $benchmark->register(sprintf('Aura v2 - last route (%s routes)', $numRoutes), function () use ($routes, $lastStr) {
         $router = new Aura\Router\Router(
@@ -218,21 +218,21 @@ function setupABRouter(Benchmark $benchmark, $numRoutes, $args)
     $firstStr = $routes[0];
     $lastStr = $routes[$numRoutes - 1];
 
-    $benchmark->register(sprintf('AdamBrett\\Router - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
-        $router = new AdamBrett\Router\FactoryRouter(
-            new AdamBrett\Router\Router('GET', $firstStr)
-        );
+    // $benchmark->register(sprintf('AdamBrett\\Router - first route (%s routes)', $numRoutes), function () use ($routes, $firstStr) {
+    //     $router = new AdamBrett\Router\FactoryRouter(
+    //         new AdamBrett\Router\Router('GET', $firstStr)
+    //     );
 
-        foreach ($routes as $i => $route) {
-            $router->get($route, function () use ($i) {
-                if (function_exists('handle' . $i)) {
-                    call_user_func('handle' . $i);
-                }
-            });
-        }
+    //     foreach ($routes as $i => $route) {
+    //         $router->get($route, function () use ($i) {
+    //             if (function_exists('handle' . $i)) {
+    //                 call_user_func('handle' . $i);
+    //             }
+    //         });
+    //     }
 
-        $router->dispatch();
-    });
+    //     $router->dispatch();
+    // });
 
     $benchmark->register(sprintf('AdamBrett\\Router - last route (%s routes)', $numRoutes), function () use ($routes, $lastStr) {
         $router = new AdamBrett\Router\FactoryRouter(

--- a/tests.php
+++ b/tests.php
@@ -11,187 +11,182 @@ function getRandomParts()
     );
 }
 
+function getRoutes($numRoutes, $argString)
+{
+    $routes = [];
+    for ($i = 0; $i < $numRoutes; $i++) {
+        list ($pre, $post) = getRandomParts();
+        $route = '/' . $pre . '/' . $argString . '/' . $post;
+        $routes[] = $route;
+    }
+
+    return $routes;
+}
 /**
  * Sets up FastRoute tests
  */
-function setupFastRoute(Benchmark $benchmark, $routes, $args)
+function setupFastRoute(Benchmark $benchmark, $numRoutes, $args)
 {
     $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
-    $str = $firstStr = $lastStr = '';
-    $router = FastRoute\simpleDispatcher(function ($router) use ($routes, $argString, &$lastStr) {
-            for ($i = 0; $i < $routes; $i++) {
-                list ($pre, $post) = getRandomParts();
-                $str = '/' . $pre . '/' . $argString . '/' . $post;
 
-                if (0 === $i) {
-                    $firstStr = $str;
-                }
-                $lastStr = $str;
+    $routes = getRoutes($numRoutes, $argString);
+    $lastStr = $routes[$numRoutes - 1];
 
-                $router->addRoute('GET', $str, 'handler' . $i);
+    $benchmark->register(sprintf('FastRoute - last route (%s routes)', $numRoutes), function () use ($routes, $lastStr) {
+        $router = FastRoute\simpleDispatcher(function ($router) use ($routes) {
+            foreach ($routes as $i => $route) {
+                $router->addRoute('GET', $route, 'handler' . $i);
             }
         });
 
-//    $benchmark->register(sprintf('FastRoute - first route', $routes), function () use ($router, $firstStr) {
-//            $route = $router->dispatch('GET', $firstStr);
-//        });
+        $route = $router->dispatch('GET', $lastStr);
+    });
 
-    $benchmark->register(sprintf('FastRoute - last route (%s routes)', $routes), function () use ($router, $lastStr) {
-            $route = $router->dispatch('GET', $lastStr);
+    $benchmark->register(sprintf('FastRoute - unknown route (%s routes)', $numRoutes), function () use ($routes) {
+        $router = FastRoute\simpleDispatcher(function ($router) use ($routes) {
+            foreach ($routes as $i => $route) {
+                $router->addRoute('GET', $route, 'handler' . $i);
+            }
         });
 
-    $benchmark->register(sprintf('FastRoute - unknown route (%s routes)', $routes), function () use ($router) {
-            $route = $router->dispatch('GET', '/not-even-real');
-        });
+        $route = $router->dispatch('GET', '/not-even-real');
+    });
 }
 
 /**
  * Sets up Pux tests
  */
-function setupPux(Benchmark $benchmark, $routes, $args)
+function setupPux(Benchmark $benchmark, $numRoutes, $args)
 {
     $argString = implode('/', array_map(function ($i) { return ':arg' . $i; }, range(1, $args)));
-    $str = $firstStr = $lastStr = '';
-    $router = new Pux\Mux;
-    for ($i = 0; $i < $routes; $i++) {
-        list ($pre, $post) = getRandomParts();
-        $str = '/' . $pre . '/' . $argString . '/' . $post;
 
-        if (0 === $i) {
-            $firstStr = $str;
+    $routes = getRoutes($numRoutes, $argString);
+    $lastStr = $routes[$numRoutes - 1];
+
+
+    $benchmark->register(sprintf('Pux PHP - last route (%s routes)', $numRoutes), function () use ($routes, $lastStr) {
+        $router = new Pux\Mux;
+        foreach ($routes as $i => $route) {
+            $router->add($route, 'handler' . $i);
         }
-        $lastStr = $str;
+        $route = $router->match($lastStr);
+    });
 
-        $router->add($str, 'handler' . $i);
-    }
-
-//    $benchmark->register('Pux PHP - first route', function () use ($router, $firstStr) {
-//            $route = $router->match($firstStr);
-//        });
-
-    $benchmark->register(sprintf('Pux PHP - last route (%s routes)', $routes), function () use ($router, $lastStr) {
-            $route = $router->match($lastStr);
-        });
-
-    $benchmark->register(sprintf('Pux PHP - unknown route (%s routes)', $routes), function () use ($router) {
-            $route = $router->match('GET', '/not-even-real');
-        });
+    $benchmark->register(sprintf('Pux PHP - unknown route (%s routes)', $numRoutes), function () use ($routes) {
+        $router = new Pux\Mux;
+        foreach ($routes as $i => $route) {
+            $router->add($route, 'handler' . $i);
+        }
+        $route = $router->match('GET', '/not-even-real');
+    });
 }
 
 /**
  * Sets up Symfony 2 tests
  */
-function setupSymfony2(Benchmark $benchmark, $routes, $args)
+function setupSymfony2(Benchmark $benchmark, $numRoutes, $args)
 {
     $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
-    $str = $firstStr = $lastStr = '';
-    $sfRoutes = new Symfony\Component\Routing\RouteCollection();
-    $router = new Symfony\Component\Routing\Matcher\UrlMatcher($sfRoutes, new Symfony\Component\Routing\RequestContext());
-    for ($i = 0, $str = 'a'; $i < $routes; $i++, $str++) {
-        list ($pre, $post) = getRandomParts();
-        $str = '/' . $pre . '/' . $argString . '/' . $post;
 
-        if (0 === $i) {
-            $firstStr = $str;
+    $routes = getRoutes($numRoutes, $argString);
+    $lastStr = $routes[$numRoutes - 1];
+
+    $benchmark->register(sprintf('Symfony2 - last route (%s routes)', $numRoutes), function () use ($routes, $lastStr) {
+        $sfRoutes = new Symfony\Component\Routing\RouteCollection();
+        $router = new Symfony\Component\Routing\Matcher\UrlMatcher($sfRoutes, new Symfony\Component\Routing\RequestContext());
+        foreach ($routes as $i => $route) {
+            $sfRoutes->add($route, new Symfony\Component\Routing\Route($route, array('controller' => 'handler' . $i)));
         }
-        $lastStr = $str;
-        
-        $sfRoutes->add($str, new Symfony\Component\Routing\Route($str, array('controller' => 'handler' . $i)));
-    }
+        $route = $router->match($lastStr);
+    });
 
-//    $benchmark->register('Symfony2 - first route', function () use ($router, $firstStr) {
-//            $route = $router->match($firstStr);
-//        });
-
-    $benchmark->register(sprintf('Symfony2 - last route (%s routes)', $routes), function () use ($router, $lastStr) {
-            $route = $router->match($lastStr);
-        });
-
-    $benchmark->register(sprintf('Symfony2 - unknown route (%s routes)', $routes), function () use ($router) {
-            try {
-                $route = $router->match('/not-even-real');
-            } catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) { }
-        });
+    $benchmark->register(sprintf('Symfony2 - unknown route (%s routes)', $numRoutes), function () use ($routes) {
+        try {
+            $sfRoutes = new Symfony\Component\Routing\RouteCollection();
+            $router = new Symfony\Component\Routing\Matcher\UrlMatcher($sfRoutes, new Symfony\Component\Routing\RequestContext());
+            foreach ($routes as $i => $route) {
+                $sfRoutes->add($route, new Symfony\Component\Routing\Route($route, array('controller' => 'handler' . $i)));
+            }
+            $route = $router->match('/not-even-real');
+        } catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) { }
+    });
 }
 
 /**
  * Sets up Symfony2 optimized tests
  */
-function setupSymfony2Optimized(Benchmark $benchmark, $routes, $args)
+function setupSymfony2Optimized(Benchmark $benchmark, $numRoutes, $args)
 {
     $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
-    $str = $firstStr = $lastStr = '';
-    $sfRoutes = new Symfony\Component\Routing\RouteCollection();
-    for ($i = 0, $str = 'a'; $i < $routes; $i++, $str++) {
-        list ($pre, $post) = getRandomParts();
-        $str = '/' . $pre . '/' . $argString . '/' . $post;
 
-        if (0 === $i) {
-            $firstStr = $str;
-        }
-        $lastStr = $str;
-        
-        $sfRoutes->add($str, new Symfony\Component\Routing\Route($str, array('controller' => 'handler' . $i)));
+    $routes = getRoutes($numRoutes, $argString);
+    $lastStr = $routes[$numRoutes - 1];
+
+    $sfRoutes = new Symfony\Component\Routing\RouteCollection();
+
+    foreach ($routes as $i => $route) {
+        $sfRoutes->add($route, new Symfony\Component\Routing\Route($route, array('controller' => 'handler' . $i)));
     }
+
     $dumper = new Symfony\Component\Routing\Matcher\Dumper\PhpMatcherDumper($sfRoutes);
     file_put_contents(__DIR__ . '/sf2router.php', $dumper->dump());
+
     require_once __DIR__ . '/sf2router.php';
+    $benchmark->register(sprintf('Symfony2 Dumped - last route (%s routes)', $numRoutes), function () use ($lastStr) {
+        $router = new ProjectUrlMatcher(new Symfony\Component\Routing\RequestContext());
+        $route = $router->match($lastStr);
+    });
 
-    $router = new ProjectUrlMatcher(new Symfony\Component\Routing\RequestContext());
-
-//    $benchmark->register('Symfony2 Dumped - first route', function () use ($router, $firstStr) {
-//            $route = $router->match($firstStr);
-//        });
-
-    $benchmark->register(sprintf('Symfony2 Dumped - last route (%s routes)', $routes), function () use ($router, $lastStr) {
-            $route = $router->match($lastStr);
-        });
-
-    $benchmark->register(sprintf('Symfony2 Dumped - unknown route (%s routes)', $routes), function () use ($router) {
-            try {
-                $route = $router->match('/not-even-real');
-            } catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) { }
-        });
+    $benchmark->register(sprintf('Symfony2 Dumped - unknown route (%s routes)', $numRoutes), function () {
+        try {
+            $router = new ProjectUrlMatcher(new Symfony\Component\Routing\RequestContext());
+            $route = $router->match('/not-even-real');
+        } catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) { }
+    });
 }
 
 /**
  * Sets up Aura v2 tests
- * 
+ *
  * https://github.com/auraphp/Aura.Router
  */
-function setupAura2(Benchmark $benchmark, $routes, $args)
+function setupAura2(Benchmark $benchmark, $numRoutes, $args)
 {
     $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
-    $lastStr = '';
-    $router = new Aura\Router\Router(
-        new Aura\Router\RouteCollection(
-            new Aura\Router\RouteFactory()
-        )
-    );
-    for ($i = 0, $str = 'a'; $i < $routes; $i++, $str++) {
-        list ($pre, $post) = getRandomParts();
-        $str = '/' . $pre . '/' . $argString . '/' . $post;
+    $routes = getRoutes($numRoutes, $argString);
+    $lastStr = $routes[$numRoutes - 1];
 
-        if (0 === $i) {
-            $firstStr = $str;
+    $benchmark->register(sprintf('Aura v2 - last route (%s routes)', $numRoutes), function () use ($routes, $lastStr) {
+        $router = new Aura\Router\Router(
+            new Aura\Router\RouteCollection(
+                new Aura\Router\RouteFactory()
+            )
+        );
+
+        foreach ($routes as $i => $route) {
+            $router->add($route, $route)
+                ->addValues(array(
+                    'controller' => 'handler' . $i
+                ));
         }
-        $lastStr = $str;
-        
-        $router->add($str, $str)
-            ->addValues(array(
-                'controller' => 'handler' . $i
-            ));
-    }
 
-//    $benchmark->register('Aura v2 - first route', function () use ($router, $firstStr) {
-//            $route = $router->match($firstStr);
-//        });
-    
-    $benchmark->register(sprintf('Aura v2 - last route (%s routes)', $routes), function () use ($router, $lastStr) {
         $route = $router->match($lastStr, $_SERVER);
     });
 
-    $benchmark->register(sprintf('Aura v2 - unknown route (%s routes)', $routes), function () use ($router) {
+    $benchmark->register(sprintf('Aura v2 - unknown route (%s routes)', $numRoutes), function () use ($routes) {
+        $router = new Aura\Router\Router(
+            new Aura\Router\RouteCollection(
+                new Aura\Router\RouteFactory()
+            )
+        );
+
+        foreach ($routes as $i => $route) {
+            $router->add($route, $route)
+                ->addValues(array(
+                    'controller' => 'handler' . $i
+                ));
+        }
+
         $route = $router->match('/not-even-real', $_SERVER);
     });
 }


### PR DESCRIPTION
Hi,

I originally just wanted to test adding [my little router package](http://github.com/adambrett/php-router) to see how it compared, but when it totally blew all the others away I knew something was wrong because I wrote mine with absolutely no consideration for speed.

A bit on investigation showed that the issue was the way in which things are dispatched, and that my router does the matching when routes are added, and then discards anything else immediately.  That lead me to the conclusion that a fairer comparison is the assembly of the router as well as dispatch process, that lead to the following figures:

| Test Name | Time | \+ Interval | Change |
| --- | --- | --- | --- |
| AdamBrett\Router - unknown route (1000 routes) | 0.0313445032 | +0.0000000000 | baseline |
| AdamBrett\Router - last route (1000 routes) | 0.0320222467 | +0.0006777436 | 2% slower |
| FastRoute - last route (1000 routes) | 0.1440973312 | +0.1127528280 | 360% slower |
| FastRoute - unknown route (1000 routes) | 0.1482576191 | +0.1169131160 | 373% slower |
| Aura v2 - unknown route (1000 routes) | 0.1633502930 | +0.1320057899 | 421% slower |
| Aura v2 - last route (1000 routes) | 0.1638579160 | +0.1325134128 | 423% slower |
| Pux PHP - unknown route (1000 routes) | 0.2488152713 | +0.2174707681 | 694% slower |
| Pux PHP - last route (1000 routes) | 0.2528938979 | +0.2215493947 | 707% slower |
| Symfony2 - last route (1000 routes) | 0.4613442034 | +0.4299997002 | 1372% slower |
| Symfony2 - unknown route (1000 routes) | 0.4683836937 | +0.4370391905 | 1394% slower |

Clearly this still isn't right, as FastRoute should be far faster than my package, which lead me to separate out the Dumped Symfony2 router, and write some rudimentary caching for the other routes (so the impact of building the router becomes negligible), which lead to the following figures:

| Test Name | Time | \+ Interval | Change |
| --- | --- | --- | --- |
| Symfony2 Dumped - unknown route (1000 routes) | 0.0011271983 | +0.0000000000 | baseline |
| Symfony2 Dumped - last route (1000 routes) | 0.0011997283 | +0.0000725299 | 6% slower |
| FastRoute Cached - last route (1000 routes) | 0.0056380630 | +0.0045108646 | 400% slower |
| FastRoute Cached - unknown route (1000 routes) | 0.0058212489 | +0.0046940505 | 416% slower |
| AdamBrett\Router - last route (1000 routes) | 0.0299270600 | +0.0287998617 | 2555% slower |
| AdamBrett\Router - unknown route (1000 routes) | 0.0303771615 | +0.0292499632 | 2595% slower |
| Pux PHP - last route (1000 routes) | 0.0309612066 | +0.0298340082 | 2647% slower |
| Pux PHP - unknown route (1000 routes) | 0.0314295948 | +0.0303023964 | 2688% slower |
| Aura v2 - last route (1000 routes) | 0.0978639692 | +0.0967367709 | 8582% slower |
| Aura v2 - unknown route (1000 routes) | 0.1023280859 | +0.1012008876 | 8978% slower |

As the way my router is designed means it's impossible to cache I have left it uncached.  I suspect that Symfony comes out so much faster because it's writing a PHP class rather than serializing and unserializing the router object.

I guess this shows a few things:

1) The rankings are slightly different from the original benchmark because the way routes are assembled has an impact
2) It's important to cache your router in production
