### PR TITLE
Add: AdamBrett\Router

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "nikic/fast-route": "dev-master",
     "corneltek/pux": "dev-master",
     "symfony/routing": "dev-master",
-    "aura/router": "dev-develop-2"
+    "aura/router": "dev-develop-2",
+    "adambrett/router": "dev-master"
   }
 }

--- a/worst-case-tests.php
+++ b/worst-case-tests.php
@@ -31,6 +31,7 @@ function setupBenchmark($numIterations, $numRoutes, $numArgs)
     setupSymfony2($benchmark, $numRoutes, $numArgs);
     setupSymfony2Optimized($benchmark, $numRoutes, $numArgs);
     setupPux($benchmark, $numRoutes, $numArgs);
+    setupABRouter($benchmark, $numRoutes, $numArgs);
 
     return $benchmark;
 }
@@ -211,5 +212,43 @@ function setupAura2(Benchmark $benchmark, $routes, $args)
 
     $benchmark->register(sprintf('Aura v2 - unknown route (%s routes)', $routes), function () use ($router) {
             $route = $router->match('/not-even-real', $_SERVER);
+        });
+}
+
+/**
+ * Sets up AdamBrett\Router tests
+ *
+ * https://github.com/adambrett/router
+ */
+function setupABRouter(Benchmark $benchmark, $routes, $args)
+{
+    $argString = implode('/', array_map(function ($i) { return "{arg$i}"; }, range(1, $args)));
+    $lastStr = '';
+    $router = new \AdamBrett\Router\FactoryRouter(
+        new \AdamBrett\Router\SerializableRouter(null, null)
+    );
+
+    for ($i = 0, $str = 'a'; $i < $routes; $i++, $str++) {
+        list ($pre, $post) = getRandomParts();
+        $str = '/' . $pre . '/' . $argString . '/' . $post;
+
+        if (0 === $i) {
+            $firstStr = str_replace(array('{', '}'), '', $str);
+        }
+        $lastStr = str_replace(array('{', '}'), '', $str);
+
+        $router->get($str, function ($params) {
+            if (function_exists('handler' . $i)) {
+                call_user_func_array('handler' . $i, $params);
+            }
+        });
+    }
+
+    $benchmark->register(sprintf('AdamBrett\\Router - last route (%s routes)', $routes), function () use ($router, $lastStr) {
+            $route = $router->dispatch('GET', $lastStr);
+        });
+
+    $benchmark->register(sprintf('AdamBrett\\Router - unknown route (%s routes)', $routes), function () use ($router) {
+            $route = $router->dispatch('GET', '/not-even-real');
         });
 }


### PR DESCRIPTION
Hi,

I haven't had looked at the full router build benchmark yet, but I have added a serializable version of my router so that it can be fairly compared to the other routers.  It still comes out way faster than I think it should, so I have probably done something wrong!  Any guidance you can give would be great.  The figures I got are below:

This benchmark consists of 12 tests. Each test is executed 1,000 times, the results pruned, and then averaged. Values that fall outside of 3 standard deviations of the mean are discarded.

| Test Name | Results | Time | \+ Interval | Change |
| --- | --- | --- | --- | --- |
| AdamBrett\Router - unknown route (1000 routes) | 984 | 0.0000121007 | +0.0000000000 | baseline |
| AdamBrett\Router - last route (1000 routes) | 988 | 0.0000123608 | +0.0000002601 | 2% slower |
| FastRoute - unknown route (1000 routes) | 989 | 0.0009440708 | +0.0009319701 | 7702% slower |
| FastRoute - last route (1000 routes) | 999 | 0.0010252782 | +0.0010131775 | 8373% slower |
| Symfony2 Dumped - unknown route (1000 routes) | 1,000 | 0.0013954713 | +0.0013833706 | 11432% slower |
| Pux PHP - unknown route (1000 routes) | 962 | 0.0023345717 | +0.0023224710 | 19193% slower |
| Pux PHP - last route (1000 routes) | 999 | 0.0023385731 | +0.0023264725 | 19226% slower |
| Symfony2 Dumped - last route (1000 routes) | 985 | 0.0047210321 | +0.0047089314 | 38915% slower |
| Symfony2 - last route (1000 routes) | 999 | 0.0066727893 | +0.0066606886 | 55044% slower |
| Symfony2 - unknown route (1000 routes) | 998 | 0.0071185701 | +0.0071064694 | 58728% slower |
| Aura v2 - last route (1000 routes) | 999 | 0.0073270211 | +0.0073149204 | 60450% slower |
| Aura v2 - unknown route (1000 routes) | 996 | 0.0097585794 | +0.0097464788 | 80545% slower |
## First route matching

This benchmark tests how quickly each router can match the first route. 1,000 routes each with 9 arguments.

This benchmark consists of 6 tests. Each test is executed 1,000 times, the results pruned, and then averaged. Values that fall outside of 3 standard deviations of the mean are discarded.

| Test Name | Results | Time | \+ Interval | Change |
| --- | --- | --- | --- | --- |
| AdamBrett\Router - first route | 993 | 0.0000118510 | +0.0000000000 | baseline |
| FastRoute - first route | 997 | 0.0000249696 | +0.0000131186 | 111% slower |
| Pux PHP - first route | 985 | 0.0000253540 | +0.0000135029 | 114% slower |
| Symfony2 Dumped - first route | 977 | 0.0000557101 | +0.0000438591 | 370% slower |
| Aura v2 - first route | 993 | 0.0001643055 | +0.0001524544 | 1286% slower |
| Symfony2 - first route | 992 | 0.0001835614 | +0.0001717104 | 1449% slower |

[These](https://github.com/adambrett/php-router/commit/7d5f5ec594db1538a9e7f2d8317222381a3e264b) are the relevant changes in my router library, specifically it's the `SerializableRouter` and `RouteCollection` classes and `Route::matches` method being run in the benchmark.
